### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = function(options) {
         var stream = this,
             configFile = file.path,
             isWin = /^win/.test(process.platform),
-            wdioBin = path.join(__dirname, 'node_modules', '.bin', isWin ? 'wdio.cmd' : 'wdio');
+            wdioBin = require.resolve(path.join('webdriverio', 'bin', isWin ? 'wdio.cmd' : 'wdio'));
 
         var opts = deepmerge({
             wdioBin: wdioBin


### PR DESCRIPTION
fix wedriverio bin path issue due to flattening dependency, based on https://github.com/npm/npm/issues/9718#issuecomment-142464880 solution. 

!!! only tested on npm 2.14.2 and node v4.0.0 on MacOS 10.9.5
